### PR TITLE
update Table annotation property client, make it type string from str…

### DIFF
--- a/src/Annotation/Table.php
+++ b/src/Annotation/Table.php
@@ -13,7 +13,7 @@ class Table
     /**
      * 客户端名称.
      *
-     * @var string|null
+     * @var string
      */
     public $client;
 


### PR DESCRIPTION
我这边给client赋值会出现这个报错

Fatal error: Uncaught Doctrine\Common\Annotations\AnnotationException: [Type Error] Attribute "client" of @Table declared on class expects a(n) string|null, but got string. in /vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/AnnotationException.php:64

对应的版本为
```
 "name": "doctrine/annotations",
            "version": "1.13.2",
            "source": {
                "type": "git",
                "url": "https://github.com/doctrine/annotations.git",
                "reference": "5b668aef16090008790395c02c893b1ba13f7e08"
            },
```
